### PR TITLE
fix: Path to philanthropy image

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -216,7 +216,7 @@ const metadata = {
       },
     ]}
     image={{
-      src: 'src/assets/images/romain-dancre-doplSDELX7E-unsplash.jpg',
+      src: '~/assets/images/romain-dancre-doplSDELX7E-unsplash.jpg',
       alt: 'Image of people working on paperwork',
     }}
   >


### PR DESCRIPTION
The path to the image for the local grant-makers section was broken
This fixes that path so the image can load.